### PR TITLE
Alias warn method

### DIFF
--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -36,7 +36,7 @@ module Twiglet
       log(level: 'warning', message: message)
     end
 
-    alias :warn :warning
+    alias_method :warn, :warning
 
     def error(message, error = nil)
       if error

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -36,6 +36,8 @@ module Twiglet
       log(level: 'warning', message: message)
     end
 
+    alias :warn :warning
+
     def error(message, error = nil)
       if error
         message = message.merge({

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.0.0-alpha.1'
+  VERSION = '2.0.0-alpha.2'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -191,11 +191,12 @@ describe Twiglet::Logger do
   ]
 
   levels.each do |attrs|
-    it 'should correctly log level' do
+    it "should correctly log level when calling #{attrs[:method]}" do
       @logger.public_send(attrs[:method], {message: 'a log message'})
       actual_log = read_json(@buffer)
 
       assert_equal attrs[:level], actual_log[:log][:level]
+      assert_equal 'a log message', actual_log[:message]
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -182,6 +182,23 @@ describe Twiglet::Logger do
     assert_match 'logger_test.rb', actual_log[:backtrace].first
   end
 
+  levels = [
+    { method: :debug, level: 'debug' },
+    { method: :info, level: 'info' },
+    { method: :warning, level: 'warning' },
+    { method: :warn, level: 'warning' },
+    { method: :error, level: 'error' }
+  ]
+
+  levels.each do |attrs|
+    it 'should correctly log level' do
+      @logger.public_send(attrs[:method], {message: 'a log message'})
+      actual_log = read_json(@buffer)
+
+      assert_equal attrs[:level], actual_log[:log][:level]
+    end
+  end
+
   private
 
   def read_json(buffer)


### PR DESCRIPTION
# Changes
- adds an alias `warn` for the `warning` method
- tests the logged level for all methods in the public interface

@simplybusiness/application-tooling  