### PR TITLE
Error message and stack trace logging not ECS compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ This will write to STDOUT a JSON string:
 
 Obviously the timestamp will be different.
 
+Errors can be logged as well, and this will log the error message and backtrace in the relevant ECS compliant fields:
+
+```ruby
+db_err = StandardError.new('Connection timed-out')
+logger.error({ message: 'DB connection failed.' }, db_err)
+```
+
 Add log event specific information simply as attributes in a hash:
 
 ```ruby

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -39,8 +39,8 @@ module Twiglet
     def error(message, error = nil)
       if error
         message = message.merge({
-                                  error_name: error.message,
-                                  backtrace: error.backtrace
+                                  'error.message': error.message,
+                                  'error.stack_trace': error.backtrace.join("\n")
                                 })
       end
 

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -39,8 +39,10 @@ module Twiglet
     def error(message, error = nil)
       if error
         message = message.merge({
-                                  'error.message': error.message,
-                                  'error.stack_trace': error.backtrace.join("\n")
+                                  'error': {
+                                    'message': error.message,
+                                    'stack_trace': error.backtrace.join("\n")
+                                  }
                                 })
       end
 

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.0.0-alpha.1'
+  VERSION = '2.0.0'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -178,8 +178,8 @@ describe Twiglet::Logger do
     actual_log = read_json(@buffer)
 
     assert_equal 'Artificially raised exception', actual_log[:message]
-    assert_equal 'divided by 0', actual_log[:error_name]
-    assert_match 'logger_test.rb', actual_log[:backtrace].first
+    assert_equal 'divided by 0', actual_log[:error][:message]
+    assert_match 'logger_test.rb', actual_log[:error][:stack_trace].lines.first
   end
 
   private


### PR DESCRIPTION
With this change logs will look like:

```json
{
   "service":{
      "name":"petshop"
   },
   "@timestamp":"2020-05-11T15:01:01.000Z",
   "log":{
      "level":"error"
   },
   "message":"Artificially raised exception",
   "error":{
      "message":"divided by 0",
      "stack_trace":"..."
   }
}
```