### PR TITLE
Support text log

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   Documentation:
     Enabled: false
 Metrics/BlockLength:
-  Max: 200
+  Max: 250
 Metrics/AbcSize:
   Max: 20
 Metrics/MethodLength:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ This will write to STDOUT a JSON string:
 
 Obviously the timestamp will be different.
 
+Alternatively, if you just want to log some error message in text format
+```ruby
+logger.error( "Emergency! There's an Emergency going on")
+```
+
+This will write to STDOUT a JSON string:
+
+```json
+{"service":{"name":"service name"},"@timestamp":"2020-05-14T10:54:59.164+01:00","log":{"level":"error"}, "message":"Emergency! There's an Emergency going on"}
+```
+
 Errors can be logged as well, and this will log the error message and backtrace in the relevant ECS compliant fields:
 
 ```ruby
@@ -67,6 +78,18 @@ This writes:
 ```json
 {"service":{"name":"service name"},"@timestamp":"2020-05-14T10:56:49.527+01:00","log":{"level":"info"},"event":{"action":"HTTP request"},"message":"GET /pets success","trace":{"id":"1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb"},"http":{"request":{"method":"get"},"response":{"status_code":200}},"url":{"path":"/pets"}}
 ```
+
+Similar to error you can use text logging here as:
+
+```
+logger.info('GET /pets success')
+```
+This writes:
+
+```json
+{"service":{"name":"service name"},"@timestamp":"2020-05-14T10:56:49.527+01:00","log":{"level":"info"}}
+```
+
 
 It may be that when making a series of logs that write information about a single event, you may want to avoid duplication by creating an event specific logger that includes the context:
 

--- a/example_app.rb
+++ b/example_app.rb
@@ -17,6 +17,9 @@ logger.info({
               }
             })
 
+# Use text logging
+logger.info("Ready to go, listening on port #{PORT}")
+#
 # We get a request
 request_logger = logger.with({
                                event: {

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -67,6 +67,8 @@ module Twiglet
     def log(level:, message:)
       case message
       when String
+        raise('The \'message\' property of log object must not be empty') if message.strip.empty?
+
         message = { message: message }
       when Hash
         message = message.transform_keys(&:to_sym)

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -12,176 +12,6 @@ describe Twiglet::Logger do
                                   output: @buffer)
   end
 
-  it 'should throw an error with an empty service name' do
-    assert_raises RuntimeError do
-      Twiglet::Logger.new('  ')
-    end
-  end
-
-  it 'should throw an error with an empty message' do
-    assert_raises RuntimeError do
-      @logger.info('')
-    end
-  end
-
-  it 'should log mandatory attributes' do
-    @logger.error({message: 'Out of pets exception'})
-    actual_log = read_json(@buffer)
-
-    expected_log = {
-      message: 'Out of pets exception',
-      "@timestamp": '2020-05-11T15:01:01.000Z',
-      service: {
-        name: 'petshop'
-      },
-      log: {
-        level: 'error'
-      }
-    }
-
-    assert_equal expected_log, actual_log
-  end
-
-  it 'should log the provided message' do
-    @logger.error({event:
-                     {action: 'exception'},
-                   message: 'Emergency! Emergency!'})
-    log = read_json(@buffer)
-
-    assert_equal 'exception', log[:event][:action]
-    assert_equal 'Emergency! Emergency!', log[:message]
-  end
-
-  it 'should log scoped properties defined at creation' do
-    extra_properties = {
-      trace: {
-        id: '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'
-      },
-      service: {
-        type: 'shop'
-      },
-      request: {method: 'get'},
-      response: {status_code: 200}
-    }
-
-    output = StringIO.new
-    logger = Twiglet::Logger.new('petshop',
-                                 now: @now,
-                                 output: output,
-                                 default_properties: extra_properties)
-
-    logger.error({message: 'GET /cats'})
-    log = read_json output
-
-    assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', log[:trace][:id]
-    assert_equal 'petshop', log[:service][:name]
-    assert_equal 'shop', log[:service][:type]
-    assert_equal 'get', log[:request][:method]
-    assert_equal 200, log[:response][:status_code]
-  end
-
-  it "should be able to add properties with '.with'" do
-    # Let's add some context to this customer journey
-    purchase_logger = @logger.with({
-                                     trace: {id: '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'},
-                                     customer: {full_name: 'Freda Bloggs'},
-                                     event: {action: 'pet purchase'}
-                                   })
-
-    # do stuff
-    purchase_logger.info({
-                           message: 'customer bought a dog',
-                           pet: {name: 'Barker', species: 'dog', breed: 'Bitsa'}
-                         })
-
-    log = read_json @buffer
-
-    assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', log[:trace][:id]
-    assert_equal 'Freda Bloggs', log[:customer][:full_name]
-    assert_equal 'pet purchase', log[:event][:action]
-    assert_equal 'customer bought a dog', log[:message]
-    assert_equal 'Barker', log[:pet][:name]
-  end
-
-  it "should log 'message' string property" do
-    message = {}
-    message['message'] = 'Guinea pigs arrived'
-    @logger.debug(message)
-    log = read_json(@buffer)
-
-    assert_equal 'Guinea pigs arrived', log[:message]
-  end
-
-  it 'should be able to convert dotted keys to nested objects' do
-    @logger.debug({
-                    "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
-                    message: 'customer bought a dog',
-                    "pet.name": 'Barker',
-                    "pet.species": 'dog',
-                    "pet.breed": 'Bitsa'
-                  })
-    log = read_json(@buffer)
-
-    assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', log[:trace][:id]
-    assert_equal 'customer bought a dog', log[:message]
-    assert_equal 'Barker', log[:pet][:name]
-    assert_equal 'dog', log[:pet][:species]
-    assert_equal 'Bitsa', log[:pet][:breed]
-  end
-
-  it 'should be able to mix dotted keys and nested objects' do
-    @logger.debug({
-                    "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
-                    message: 'customer bought a dog',
-                    pet: {name: 'Barker', breed: 'Bitsa'},
-                    "pet.species": 'dog'
-                  })
-    log = read_json(@buffer)
-
-    assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', log[:trace][:id]
-    assert_equal 'customer bought a dog', log[:message]
-    assert_equal 'Barker', log[:pet][:name]
-    assert_equal 'dog', log[:pet][:species]
-    assert_equal 'Bitsa', log[:pet][:breed]
-  end
-
-  it 'should work with mixed string and symbol properties' do
-    log = {
-      "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'
-    }
-    event = {}
-    log['event'] = event
-    log['message'] = 'customer bought a dog'
-    pet = {}
-    pet['name'] = 'Barker'
-    pet['breed'] = 'Bitsa'
-    pet[:species] = 'dog'
-    log[:pet] = pet
-
-    @logger.debug(log)
-    actual_log = read_json(@buffer)
-
-    assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', actual_log[:trace][:id]
-    assert_equal 'customer bought a dog', actual_log[:message]
-    assert_equal 'Barker', actual_log[:pet][:name]
-    assert_equal 'dog', actual_log[:pet][:species]
-    assert_equal 'Bitsa', actual_log[:pet][:breed]
-  end
-
-  it 'should log an error with backtrace' do
-    begin
-      1 / 0
-    rescue StandardError => e
-      @logger.error({message: 'Artificially raised exception'}, e)
-    end
-
-    actual_log = read_json(@buffer)
-
-    assert_equal 'Artificially raised exception', actual_log[:message]
-    assert_equal 'divided by 0', actual_log[:error][:message]
-    assert_match 'logger_test.rb', actual_log[:error][:stack_trace].lines.first
-  end
-
   levels = [
     { method: :debug, level: 'debug' },
     { method: :info, level: 'info' },
@@ -190,13 +20,219 @@ describe Twiglet::Logger do
     { method: :error, level: 'error' }
   ]
 
-  levels.each do |attrs|
-    it "should correctly log level when calling #{attrs[:method]}" do
-      @logger.public_send(attrs[:method], {message: 'a log message'})
+  it 'should throw an error with an empty service name' do
+    assert_raises RuntimeError do
+      Twiglet::Logger.new('  ')
+    end
+  end
+
+  describe 'JSON logging' do
+    it 'should throw an error with an empty message' do
+      assert_raises RuntimeError do
+        @logger.info({message: ''})
+      end
+    end
+
+    it 'should log mandatory attributes' do
+      @logger.error({message: 'Out of pets exception'})
       actual_log = read_json(@buffer)
 
-      assert_equal attrs[:level], actual_log[:log][:level]
-      assert_equal 'a log message', actual_log[:message]
+      expected_log = {
+        message: 'Out of pets exception',
+        "@timestamp": '2020-05-11T15:01:01.000Z',
+        service: {
+          name: 'petshop'
+        },
+        log: {
+          level: 'error'
+        }
+      }
+
+      assert_equal expected_log, actual_log
+    end
+
+    it 'should log the provided message' do
+      @logger.error({event:
+                       {action: 'exception'},
+                     message: 'Emergency! Emergency!'})
+      log = read_json(@buffer)
+
+      assert_equal 'exception', log[:event][:action]
+      assert_equal 'Emergency! Emergency!', log[:message]
+    end
+
+    it 'should log scoped properties defined at creation' do
+      extra_properties = {
+        trace: {
+          id: '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'
+        },
+        service: {
+          type: 'shop'
+        },
+        request: {method: 'get'},
+        response: {status_code: 200}
+      }
+
+      output = StringIO.new
+      logger = Twiglet::Logger.new('petshop',
+                                   now: @now,
+                                   output: output,
+                                   default_properties: extra_properties)
+
+      logger.error({message: 'GET /cats'})
+      log = read_json output
+
+      assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', log[:trace][:id]
+      assert_equal 'petshop', log[:service][:name]
+      assert_equal 'shop', log[:service][:type]
+      assert_equal 'get', log[:request][:method]
+      assert_equal 200, log[:response][:status_code]
+    end
+
+    it "should be able to add properties with '.with'" do
+      # Let's add some context to this customer journey
+      purchase_logger = @logger.with({
+                                       trace: {id: '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'},
+                                       customer: {full_name: 'Freda Bloggs'},
+                                       event: {action: 'pet purchase'}
+                                     })
+
+      # do stuff
+      purchase_logger.info({
+                             message: 'customer bought a dog',
+                             pet: {name: 'Barker', species: 'dog', breed: 'Bitsa'}
+                           })
+
+      log = read_json @buffer
+
+      assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', log[:trace][:id]
+      assert_equal 'Freda Bloggs', log[:customer][:full_name]
+      assert_equal 'pet purchase', log[:event][:action]
+      assert_equal 'customer bought a dog', log[:message]
+      assert_equal 'Barker', log[:pet][:name]
+    end
+
+    it "should log 'message' string property" do
+      message = {}
+      message['message'] = 'Guinea pigs arrived'
+      @logger.debug(message)
+      log = read_json(@buffer)
+
+      assert_equal 'Guinea pigs arrived', log[:message]
+    end
+
+    it 'should be able to convert dotted keys to nested objects' do
+      @logger.debug({
+                      "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
+                      message: 'customer bought a dog',
+                      "pet.name": 'Barker',
+                      "pet.species": 'dog',
+                      "pet.breed": 'Bitsa'
+                    })
+      log = read_json(@buffer)
+
+      assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', log[:trace][:id]
+      assert_equal 'customer bought a dog', log[:message]
+      assert_equal 'Barker', log[:pet][:name]
+      assert_equal 'dog', log[:pet][:species]
+      assert_equal 'Bitsa', log[:pet][:breed]
+    end
+
+    it 'should be able to mix dotted keys and nested objects' do
+      @logger.debug({
+                      "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
+                      message: 'customer bought a dog',
+                      pet: {name: 'Barker', breed: 'Bitsa'},
+                      "pet.species": 'dog'
+                    })
+      log = read_json(@buffer)
+
+      assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', log[:trace][:id]
+      assert_equal 'customer bought a dog', log[:message]
+      assert_equal 'Barker', log[:pet][:name]
+      assert_equal 'dog', log[:pet][:species]
+      assert_equal 'Bitsa', log[:pet][:breed]
+    end
+
+    it 'should work with mixed string and symbol properties' do
+      log = {
+        "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'
+      }
+      event = {}
+      log['event'] = event
+      log['message'] = 'customer bought a dog'
+      pet = {}
+      pet['name'] = 'Barker'
+      pet['breed'] = 'Bitsa'
+      pet[:species] = 'dog'
+      log[:pet] = pet
+
+      @logger.debug(log)
+      actual_log = read_json(@buffer)
+
+      assert_equal '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb', actual_log[:trace][:id]
+      assert_equal 'customer bought a dog', actual_log[:message]
+      assert_equal 'Barker', actual_log[:pet][:name]
+      assert_equal 'dog', actual_log[:pet][:species]
+      assert_equal 'Bitsa', actual_log[:pet][:breed]
+    end
+
+    it 'should log an error with backtrace' do
+      begin
+        1 / 0
+      rescue StandardError => e
+        @logger.error({message: 'Artificially raised exception'}, e)
+      end
+
+      actual_log = read_json(@buffer)
+
+      assert_equal 'Artificially raised exception', actual_log[:message]
+      assert_equal 'divided by 0', actual_log[:error][:message]
+      assert_match 'logger_test.rb', actual_log[:error][:stack_trace].lines.first
+    end
+
+    levels.each do |attrs|
+      it "should correctly log level when calling #{attrs[:method]}" do
+        @logger.public_send(attrs[:method], {message: 'a log message'})
+        actual_log = read_json(@buffer)
+
+        assert_equal attrs[:level], actual_log[:log][:level]
+        assert_equal 'a log message', actual_log[:message]
+      end
+    end
+  end
+
+  describe 'text logging' do
+    it 'should throw an error with an empty message' do
+      assert_raises RuntimeError do
+        @logger.info('')
+      end
+    end
+
+    it 'should log mandatory attributes' do
+      @logger.error('Out of pets exception')
+      actual_log = read_json(@buffer)
+
+      expected_log = {
+          message: 'Out of pets exception',
+          "@timestamp": '2020-05-11T15:01:01.000Z',
+          service: {
+              name: 'petshop'
+          },
+          log: {
+              level: 'error'
+          }
+      }
+
+      assert_equal expected_log, actual_log
+    end
+
+    it 'should log the provided message' do
+      @logger.error('Emergency! Emergency!'})
+      log = read_json(@buffer)
+
+      assert_equal 'exception', log[:event][:action]
+      assert_equal 'Emergency! Emergency!', log[:message]
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -12,13 +12,13 @@ describe Twiglet::Logger do
                                   output: @buffer)
   end
 
-  levels = [
+  LEVELS = [
     { method: :debug, level: 'debug' },
     { method: :info, level: 'info' },
     { method: :warning, level: 'warning' },
     { method: :warn, level: 'warning' },
     { method: :error, level: 'error' }
-  ]
+  ].freeze
 
   it 'should throw an error with an empty service name' do
     assert_raises RuntimeError do
@@ -191,7 +191,7 @@ describe Twiglet::Logger do
       assert_match 'logger_test.rb', actual_log[:error][:stack_trace].lines.first
     end
 
-    levels.each do |attrs|
+    LEVELS.each do |attrs|
       it "should correctly log level when calling #{attrs[:method]}" do
         @logger.public_send(attrs[:method], {message: 'a log message'})
         actual_log = read_json(@buffer)
@@ -214,25 +214,34 @@ describe Twiglet::Logger do
       actual_log = read_json(@buffer)
 
       expected_log = {
-          message: 'Out of pets exception',
-          "@timestamp": '2020-05-11T15:01:01.000Z',
-          service: {
-              name: 'petshop'
-          },
-          log: {
-              level: 'error'
-          }
+        message: 'Out of pets exception',
+        "@timestamp": '2020-05-11T15:01:01.000Z',
+        service: {
+          name: 'petshop'
+        },
+        log: {
+          level: 'error'
+        }
       }
 
       assert_equal expected_log, actual_log
     end
 
     it 'should log the provided message' do
-      @logger.error('Emergency! Emergency!'})
+      @logger.error('Emergency! Emergency!')
       log = read_json(@buffer)
 
-      assert_equal 'exception', log[:event][:action]
       assert_equal 'Emergency! Emergency!', log[:message]
+    end
+
+    LEVELS.each do |attrs|
+      it "should correctly log level when calling #{attrs[:method]}" do
+        @logger.public_send(attrs[:method], 'a log message')
+        actual_log = read_json(@buffer)
+
+        assert_equal attrs[:level], actual_log[:log][:level]
+        assert_equal 'a log message', actual_log[:message]
+      end
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -17,6 +17,8 @@ describe Twiglet::Logger do
     { method: :info, level: 'info' },
     { method: :warning, level: 'warning' },
     { method: :warn, level: 'warning' },
+    { method: :critical, level: 'critical' },
+    { method: :fatal, level: 'critical' },
     { method: :error, level: 'error' }
   ].freeze
 


### PR DESCRIPTION
# What
- Support text logging in twiglet by converting text into a ECS format.
- Add few test to support that.
- some refactoring.

# Why
So we can save use the twiglet for libraries which are using text logging.


@simplybusiness/application-tooling 