### PR TITLE
[SPIKE] - Extend Ruby Logger

### DIFF
--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -5,89 +5,106 @@ require 'json'
 require_relative '../hash_extensions'
 
 module Twiglet
-  class Logger
-    attr_accessor :logging
+  class Logger < ::Logger
     def initialize(
-        service_name,
-        default_properties: {},
-        now: -> { Time.now.utc },
-        output: $stdout
+      service_name,
+      default_properties: {},
+      now: -> { Time.now.utc },
+      output: $stdout
     )
-      formatter = TwigFormat.new
-      formatter.service_name = service_name
-      formatter.now = now
-      formatter.output = output
+      @service_name = service_name
+      @now = now
+      @default_properties = default_properties
+      @output = output
+      formatter = Formatter.new(
+        service_name: service_name,
+        default_properties: default_properties,
+        now: now
+      )
 
       raise 'Service name is mandatory' \
         unless service_name.is_a?(String) && !service_name.strip.empty?
 
-      formatter.default_properties = default_properties
-
-      @logging = ::Logger.new(output, formatter: formatter)
-    end
-  end
-
-  class TwigFormat < ::Logger::Formatter
-    attr_accessor :service_name, :now, :default_properties, :output
-    Hash.include HashExtensions
-
-    def call(severity, time, progname, msg)
-      log_twig(level: severity, message: msg).to_json
+      super(output, formatter: formatter)
     end
 
-    private
-
-    def log_twig(level:, message:)
-      case message
-      when String
-        log_text(level, message: message)
-      when Hash
-        log_object(level, message: message)
-      else
-        raise('Message must be String or Hash')
-      end
-    end
-
-    def log_text(level, message:)
-      raise('The \'message\' property of log object must not be empty') if message.strip.empty?
-
-      message = { message: message }
-      log_message(level, message: message)
-    end
-
-    def log_object(level, message:)
-      message = message.transform_keys(&:to_sym)
-      message.key?(:message) || raise('Log object must have a \'message\' property')
-      message[:message].strip.empty? && raise('The \'message\' property of log object must not be empty')
-
-      log_message(level, message: message)
-    end
-
-    def log_message(level, message:)
-      base_message = {
-          "@timestamp": now.call.iso8601(3),
-          service: {
-              name: service_name
-          },
-          log: {
-              level: level
-          }
-      }
-
-      base_message
-                 .deep_merge(default_properties.to_nested)
-                 .deep_merge(message.to_nested)
-    end
-
-    def add_stack_trace(hash_to_add_to, error)
-      hash_to_add_to[:error][:stack_trace] = error.backtrace.join("\n") if error.backtrace
-    end
+    alias_method :critical, :fatal
+    alias_method :warning, :warn
 
     def with(default_properties)
-      Logger.new(service_name,
-                 default_properties: default_properties,
-                 now: now,
-                 output: output)
+      Twiglet::Logger.new(@service_name,
+                          default_properties: @default_properties,
+                          now: @now,
+                          output: @output)
+    end
+
+    class Formatter < ::Logger::Formatter
+      Hash.include HashExtensions
+
+      def initialize(
+        service_name:,
+        default_properties:,
+        now:
+      )
+        @service_name = service_name
+        @default_properties = default_properties
+        @now = now
+        super()
+      end
+
+      def call(severity, time, progname, msg)
+        level = severity.downcase
+        log(level: level, message: msg)
+      end
+
+      private
+
+      def log(level:, message:)
+        case message
+        when String
+          log_text(level, message: message)
+        when Hash
+          log_object(level, message: message)
+        else
+          raise('Message must be String or Hash')
+        end
+      end
+
+      def log_text(level, message:)
+        raise('The \'message\' property of log object must not be empty') if message.strip.empty?
+
+        message = { message: message }
+        log_message(level, message: message)
+      end
+
+      def log_object(level, message:)
+        message = message.transform_keys(&:to_sym)
+        message.key?(:message) || raise('Log object must have a \'message\' property')
+        message[:message].strip.empty? && raise('The \'message\' property of log object must not be empty')
+
+        log_message(level, message: message)
+      end
+
+      def log_message(level, message:)
+        base_message = {
+          "@timestamp": @now.call.iso8601(3),
+          service: {
+            name: @service_name
+          },
+          log: {
+            level: level
+          }
+        }
+
+        base_message
+          .deep_merge(@default_properties.to_nested)
+          .deep_merge(message.to_nested)
+          .to_json
+      end
+
+      def add_stack_trace(hash_to_add_to, error)
+        hash_to_add_to[:error][:stack_trace] = error.backtrace.join("\n") if error.backtrace
+      end
     end
   end
 end

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+
 require 'logger'
 require 'time'
 require 'json'
+
 require_relative '../hash_extensions'
 
 module Twiglet
@@ -33,7 +35,7 @@ module Twiglet
 
     def with(default_properties)
       Twiglet::Logger.new(@service_name,
-                          default_properties: @default_properties,
+                          default_properties: default_properties,
                           now: @now,
                           output: @output)
     end
@@ -52,7 +54,7 @@ module Twiglet
         super()
       end
 
-      def call(severity, time, progname, msg)
+      def call(severity, _time, _progname, msg)
         level = severity.downcase
         log(level: level, message: msg)
       end

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -16,15 +16,15 @@ module Twiglet
       @now = now
       @default_properties = default_properties
       @output = output
+
+      raise 'Service name is mandatory' \
+        unless service_name.is_a?(String) && !service_name.strip.empty?
+
       formatter = Formatter.new(
         service_name: service_name,
         default_properties: default_properties,
         now: now
       )
-
-      raise 'Service name is mandatory' \
-        unless service_name.is_a?(String) && !service_name.strip.empty?
-
       super(output, formatter: formatter)
     end
 

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -90,7 +90,7 @@ module Twiglet
         when Hash
           log_object(level, message: message)
         else
-          raise('Message must be String or Hash')
+          super.call
         end
       end
 

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -40,6 +40,25 @@ module Twiglet
                           output: @output)
     end
 
+    def error(progname = nil, error = nil, &block)
+      if error
+        error_msg = {
+          error: {
+            'message': 'error.message'
+          },
+          message: progname
+        }
+        add_stack_trace(error_msg, error)
+        super(error_msg, &block)
+      else
+        super(progname, &block)
+      end
+    end
+
+    def add_stack_trace(hash_to_add_to, error)
+      hash_to_add_to[:error][:stack_trace] = error.backtrace.join("\n") if error.backtrace
+    end
+
     class Formatter < ::Logger::Formatter
       Hash.include HashExtensions
 
@@ -102,10 +121,6 @@ module Twiglet
           .deep_merge(@default_properties.to_nested)
           .deep_merge(message.to_nested)
           .to_json
-      end
-
-      def add_stack_trace(hash_to_add_to, error)
-        hash_to_add_to[:error][:stack_trace] = error.backtrace.join("\n") if error.backtrace
       end
     end
   end

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -1,73 +1,43 @@
 # frozen_string_literal: true
-
+require 'logger'
 require 'time'
 require 'json'
 require_relative '../hash_extensions'
 
 module Twiglet
   class Logger
-    Hash.include HashExtensions
-
+    attr_accessor :logging
     def initialize(
-      service_name,
-      default_properties: {},
-      now: -> { Time.now.utc },
-      output: $stdout
+        service_name,
+        default_properties: {},
+        now: -> { Time.now.utc },
+        output: $stdout
     )
-      @service_name = service_name
-      @now = now
-      @output = output
+      formatter = TwigFormat.new
+      formatter.service_name = service_name
+      formatter.now = now
+      formatter.output = output
 
       raise 'Service name is mandatory' \
-        unless @service_name.is_a?(String) && !@service_name.strip.empty?
+        unless service_name.is_a?(String) && !service_name.strip.empty?
 
-      @default_properties = default_properties
+      formatter.default_properties = default_properties
+
+      @logging = ::Logger.new(output, formatter: formatter)
     end
+  end
 
-    def debug(message)
-      log(level: 'debug', message: message)
-    end
+  class TwigFormat < ::Logger::Formatter
+    attr_accessor :service_name, :now, :default_properties, :output
+    Hash.include HashExtensions
 
-    def info(message)
-      log(level: 'info', message: message)
-    end
-
-    def warning(message)
-      log(level: 'warning', message: message)
-    end
-
-    alias_method :warn, :warning
-
-    def error(message, error = nil)
-      if error
-        error_fields = {
-          'error': {
-            'message': error.message
-          }
-        }
-        add_stack_trace(error_fields, error)
-        message = message.merge(error_fields)
-      end
-
-      log(level: 'error', message: message)
-    end
-
-    def critical(message)
-      log(level: 'critical', message: message)
-    end
-
-    alias_method :fatal, :critical
-
-    def with(default_properties)
-      Logger.new(@service_name,
-                 default_properties: default_properties,
-                 now: @now,
-                 output: @output)
+    def call(severity, time, progname, msg)
+      log_twig(level: severity, message: msg).to_json
     end
 
     private
 
-    def log(level:, message:)
+    def log_twig(level:, message:)
       case message
       when String
         log_text(level, message: message)
@@ -95,23 +65,29 @@ module Twiglet
 
     def log_message(level, message:)
       base_message = {
-        "@timestamp": @now.call.iso8601(3),
-        service: {
-          name: @service_name
-        },
-        log: {
-          level: level
-        }
+          "@timestamp": now.call.iso8601(3),
+          service: {
+              name: service_name
+          },
+          log: {
+              level: level
+          }
       }
 
-      @output.puts base_message
-                       .deep_merge(@default_properties.to_nested)
-                       .deep_merge(message.to_nested)
-                       .to_json
+      base_message
+                 .deep_merge(default_properties.to_nested)
+                 .deep_merge(message.to_nested)
     end
 
     def add_stack_trace(hash_to_add_to, error)
       hash_to_add_to[:error][:stack_trace] = error.backtrace.join("\n") if error.backtrace
+    end
+
+    def with(default_properties)
+      Logger.new(service_name,
+                 default_properties: default_properties,
+                 now: now,
+                 output: output)
     end
   end
 end

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -43,17 +43,20 @@ module Twiglet
     def error(progname = nil, error = nil, &block)
       if error
         error_msg = {
-          error: {
-            'message': 'error.message'
-          },
-          message: progname
+          'error': {
+            'message': error.message
+          }
         }
         add_stack_trace(error_msg, error)
+        message = progname.key?(:message) ? progname : { message: progname }
+        error_msg.merge!(message)
         super(error_msg, &block)
       else
         super(progname, &block)
       end
     end
+
+    private
 
     def add_stack_trace(hash_to_add_to, error)
       hash_to_add_to[:error][:stack_trace] = error.backtrace.join("\n") if error.backtrace

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -9,15 +9,17 @@ describe Twiglet::Logger do
     @buffer = StringIO.new
     @logger = Twiglet::Logger.new('petshop',
                                   now: @now,
-                                  output: @buffer).logging
+                                  output: @buffer)
   end
 
   LEVELS = [
-    { method: :debug, level: 'DEBUG' },
-    { method: :info, level: 'INFO' },
-    { method: :warn, level: 'WARN' },
-    { method: :fatal, level: 'FATAL' },
-    { method: :error, level: 'ERROR' }
+    { method: :debug, level: 'debug' },
+    { method: :info, level: 'info' },
+    { method: :warning, level: 'warn' },
+    { method: :warn, level: 'warn' },
+    { method: :critical, level: 'fatal' },
+    { method: :fatal, level: 'fatal' },
+    { method: :error, level: 'error' }
   ].freeze
 
   it 'should throw an error with an empty service name' do
@@ -34,18 +36,18 @@ describe Twiglet::Logger do
     end
 
     it 'should log mandatory attributes' do
-      @logger.error("Out of pets exception")
+      @logger.error({message: 'Out of pets exception'})
       actual_log = read_json(@buffer)
 
       expected_log = {
+        message: 'Out of pets exception',
         "@timestamp": '2020-05-11T15:01:01.000Z',
         service: {
           name: 'petshop'
         },
         log: {
-          level: 'ERROR'
-        },
-        message: 'Out of pets exception'
+          level: 'error'
+        }
       }
 
       assert_equal expected_log, actual_log
@@ -77,7 +79,7 @@ describe Twiglet::Logger do
       logger = Twiglet::Logger.new('petshop',
                                    now: @now,
                                    output: output,
-                                   default_properties: extra_properties).logging
+                                   default_properties: extra_properties)
 
       logger.error({message: 'GET /cats'})
       log = read_json output
@@ -118,7 +120,7 @@ describe Twiglet::Logger do
       @logger.debug(message)
       log = read_json(@buffer)
 
-      # assert_equal 'Guinea pigs arrived', log[:message]
+      assert_equal 'Guinea pigs arrived', log[:message]
     end
 
     it 'should be able to convert dotted keys to nested objects' do
@@ -225,14 +227,14 @@ describe Twiglet::Logger do
       actual_log = read_json(@buffer)
 
       expected_log = {
+        message: 'Out of pets exception',
         "@timestamp": '2020-05-11T15:01:01.000Z',
         service: {
           name: 'petshop'
         },
         log: {
-          level: 'ERROR'
-        },
-        message: 'Out of pets exception'
+          level: 'error'
+        }
       }
 
       assert_equal expected_log, actual_log
@@ -243,10 +245,6 @@ describe Twiglet::Logger do
       log = read_json(@buffer)
 
       assert_equal 'Emergency! Emergency!', log[:message]
-    end
-
-    it 'should log the block' do
-      @logger.debug { "some message" }
     end
 
     LEVELS.each do |attrs|

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -255,6 +255,15 @@ describe Twiglet::Logger do
         assert_equal attrs[:level], actual_log[:log][:level]
         assert_equal 'a log message', actual_log[:message]
       end
+
+      it "should correctly log the block when calling #{attrs[:method]}" do
+        block = proc { 'a block log message' }
+        @logger.public_send(attrs[:method], &block)
+        actual_log = read_json(@buffer)
+
+        assert_equal attrs[:level], actual_log[:log][:level]
+        assert_equal 'a block log message', actual_log[:message]
+      end
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -9,17 +9,15 @@ describe Twiglet::Logger do
     @buffer = StringIO.new
     @logger = Twiglet::Logger.new('petshop',
                                   now: @now,
-                                  output: @buffer)
+                                  output: @buffer).logging
   end
 
   LEVELS = [
-    { method: :debug, level: 'debug' },
-    { method: :info, level: 'info' },
-    { method: :warning, level: 'warning' },
-    { method: :warn, level: 'warning' },
-    { method: :critical, level: 'critical' },
-    { method: :fatal, level: 'critical' },
-    { method: :error, level: 'error' }
+    { method: :debug, level: 'DEBUG' },
+    { method: :info, level: 'INFO' },
+    { method: :warn, level: 'WARN' },
+    { method: :fatal, level: 'FATAL' },
+    { method: :error, level: 'ERROR' }
   ].freeze
 
   it 'should throw an error with an empty service name' do
@@ -36,18 +34,18 @@ describe Twiglet::Logger do
     end
 
     it 'should log mandatory attributes' do
-      @logger.error({message: 'Out of pets exception'})
+      @logger.error("Out of pets exception")
       actual_log = read_json(@buffer)
 
       expected_log = {
-        message: 'Out of pets exception',
         "@timestamp": '2020-05-11T15:01:01.000Z',
         service: {
           name: 'petshop'
         },
         log: {
-          level: 'error'
-        }
+          level: 'ERROR'
+        },
+        message: 'Out of pets exception'
       }
 
       assert_equal expected_log, actual_log
@@ -79,7 +77,7 @@ describe Twiglet::Logger do
       logger = Twiglet::Logger.new('petshop',
                                    now: @now,
                                    output: output,
-                                   default_properties: extra_properties)
+                                   default_properties: extra_properties).logging
 
       logger.error({message: 'GET /cats'})
       log = read_json output
@@ -120,7 +118,7 @@ describe Twiglet::Logger do
       @logger.debug(message)
       log = read_json(@buffer)
 
-      assert_equal 'Guinea pigs arrived', log[:message]
+      # assert_equal 'Guinea pigs arrived', log[:message]
     end
 
     it 'should be able to convert dotted keys to nested objects' do
@@ -227,14 +225,14 @@ describe Twiglet::Logger do
       actual_log = read_json(@buffer)
 
       expected_log = {
-        message: 'Out of pets exception',
         "@timestamp": '2020-05-11T15:01:01.000Z',
         service: {
           name: 'petshop'
         },
         log: {
-          level: 'error'
-        }
+          level: 'ERROR'
+        },
+        message: 'Out of pets exception'
       }
 
       assert_equal expected_log, actual_log
@@ -245,6 +243,10 @@ describe Twiglet::Logger do
       log = read_json(@buffer)
 
       assert_equal 'Emergency! Emergency!', log[:message]
+    end
+
+    it 'should log the block' do
+      @logger.debug { "some message" }
     end
 
     LEVELS.each do |attrs|


### PR DESCRIPTION
# What
- Inherit ruby logger for logging.
- Use Formatter to change the format of the output.
- Logging can be done by block.

# Why
- We have seen number of cases where we have to fix the twiglet logger on case by case like for text support.
- this will use extend the ruby formatter so all functionality will come by default and we dont need to worry about any internal library using any code.

@simplybusiness/application-tooling 