### PR TITLE
Extend ruby logger

### DIFF
--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -1,0 +1,68 @@
+require 'logger'
+require_relative '../hash_extensions'
+
+module Twiglet
+  class Formatter < ::Logger::Formatter
+    Hash.include HashExtensions
+
+    def initialize(service_name,
+                   default_properties: {},
+                   now: -> { Time.now.utc })
+      @service_name = service_name
+      @now = now
+      @default_properties = default_properties
+
+      super()
+    end
+
+    def call(severity, _time, _progname, msg)
+      level = severity.downcase
+      log(level: level, message: msg)
+    end
+
+    private
+
+    def log(level:, message:)
+      case message
+      when String
+        log_text(level, message: message)
+      when Hash
+        log_object(level, message: message)
+      else
+        raise('Message must be String or Hash')
+      end
+    end
+
+    def log_text(level, message:)
+      raise('The \'message\' property of log object must not be empty') if message.strip.empty?
+
+      message = { message: message }
+      log_message(level, message: message)
+    end
+
+    def log_object(level, message:)
+      message = message.transform_keys(&:to_sym)
+      message.key?(:message) || raise('Log object must have a \'message\' property')
+      message[:message].strip.empty? && raise('The \'message\' property of log object must not be empty')
+
+      log_message(level, message: message)
+    end
+
+    def log_message(level, message:)
+      base_message = {
+        "@timestamp": @now.call.iso8601(3),
+        service: {
+          name: @service_name
+        },
+        log: {
+          level: level
+        }
+      }
+
+      base_message
+        .deep_merge(@default_properties.to_nested)
+        .deep_merge(message.to_nested)
+        .to_json
+    end
+  end
+end

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -27,7 +27,7 @@ module Twiglet
       super(output, formatter: formatter)
     end
 
-    def error(message, error = nil, &block)
+    def error(message = {}, error = nil, &block)
       if error
         error_fields = {
           'error': {
@@ -35,7 +35,7 @@ module Twiglet
           }
         }
         add_stack_trace(error_fields, error)
-        message.merge!(error_fields)
+        message.is_a?(Hash) ? message.merge!(error_fields) : error_fields.merge!(message: message)
       end
 
       super(message, &block)

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -33,7 +33,7 @@ module Twiglet
     end
 
     def warning(message)
-      log(level: 'warning', message: message)
+      log(level: 'warn', message: message)
     end
 
     def error(message, error = nil)
@@ -51,7 +51,7 @@ module Twiglet
     end
 
     def critical(message)
-      log(level: 'critical', message: message)
+      log(level: 'fatal', message: message)
     end
 
     def with(default_properties)

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
+require 'logger'
 require 'time'
 require 'json'
 require_relative '../hash_extensions'
 
 module Twiglet
-  class Logger
+  class Logger < ::Logger
     Hash.include HashExtensions
 
     def initialize(
@@ -22,6 +23,7 @@ module Twiglet
       raise 'Service name is mandatory' \
         unless @service_name.is_a?(String) && !@service_name.strip.empty?
 
+      super(output)
     end
 
     def debug(message)

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -17,11 +17,11 @@ module Twiglet
       @service_name = service_name
       @now = now
       @output = output
+      @default_properties = default_properties
 
       raise 'Service name is mandatory' \
         unless @service_name.is_a?(String) && !@service_name.strip.empty?
 
-      @default_properties = default_properties
     end
 
     def debug(message)
@@ -35,8 +35,6 @@ module Twiglet
     def warning(message)
       log(level: 'warning', message: message)
     end
-
-    alias_method :warn, :warning
 
     def error(message, error = nil)
       if error
@@ -56,14 +54,15 @@ module Twiglet
       log(level: 'critical', message: message)
     end
 
-    alias_method :fatal, :critical
-
     def with(default_properties)
       Logger.new(@service_name,
                  default_properties: default_properties,
                  now: @now,
                  output: @output)
     end
+
+    alias_method :warn, :warning
+    alias_method :fatal, :critical
 
     private
 

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'json'
+require_relative '../lib/twiglet/formatter'
+
+describe Twiglet::Formatter do
+  before do
+    @now = -> { Time.utc(2020, 5, 11, 15, 1, 1) }
+    @formatter = Twiglet::Formatter.new('petshop', now: @now)
+  end
+
+  it 'initializes an instance of a Ruby Logger Formatter' do
+    assert @formatter.is_a?(::Logger::Formatter)
+  end
+
+  it 'returns a formatted log from a string message' do
+    msg = @formatter.call('warn', nil, nil, 'shop is running low on dog food')
+    expected_log = {
+      "@timestamp" => '2020-05-11T15:01:01.000Z',
+      "service" => {
+        "name" => 'petshop'
+      },
+      "log" => {
+        "level" => 'warn'
+      },
+      "message" => 'shop is running low on dog food'
+    }
+    assert_equal JSON.parse(msg), expected_log
+  end
+end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -28,6 +28,13 @@ describe Twiglet::Logger do
     end
   end
 
+  it 'conforms to the standard Ruby Logger API' do
+    [:debug, :debug?, :info, :info?, :warn, :warn?, :fatal, :fatal?, :error, :error?,
+     :level, :level=, :sev_threshold=].each do |call|
+      assert @logger.respond_to?(call), "Logger does not respond to #{call}"
+    end
+  end
+
   describe 'JSON logging' do
     it 'should throw an error with an empty message' do
       assert_raises RuntimeError do

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -258,6 +258,32 @@ describe Twiglet::Logger do
     end
   end
 
+  describe 'logging with a block' do
+    LEVELS.each do |attrs|
+      it "should correctly log the block when calling #{attrs[:method]}" do
+        block = proc { 'a block log message' }
+        @logger.public_send(attrs[:method], &block)
+        actual_log = read_json(@buffer)
+
+        assert_equal attrs[:level], actual_log[:log][:level]
+        assert_equal 'a block log message', actual_log[:message]
+      end
+    end
+  end
+
+  describe 'logger level' do
+    [
+      { expression: :info, level: 1 },
+      { expression: 'Warn', level: 2 },
+      { expression: Logger::DEBUG, level: 0 }
+    ].each do |args|
+      it "sets the severity threshold to level #{args[:level]}" do
+        @logger.level = args[:expression]
+        assert_equal args[:level], @logger.level
+      end
+    end
+  end
+
   private
 
   def read_json(buffer)

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -15,10 +15,10 @@ describe Twiglet::Logger do
   LEVELS = [
     { method: :debug, level: 'debug' },
     { method: :info, level: 'info' },
-    { method: :warning, level: 'warning' },
-    { method: :warn, level: 'warning' },
-    { method: :critical, level: 'critical' },
-    { method: :fatal, level: 'critical' },
+    { method: :warning, level: 'warn' },
+    { method: :warn, level: 'warn' },
+    { method: :critical, level: 'fatal' },
+    { method: :fatal, level: 'fatal' },
     { method: :error, level: 'error' }
   ].freeze
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -274,7 +274,7 @@ describe Twiglet::Logger do
   describe 'logger level' do
     [
       { expression: :info, level: 1 },
-      { expression: 'Warn', level: 2 },
+      { expression: 'warn', level: 2 },
       { expression: Logger::DEBUG, level: 0 }
     ].each do |args|
       it "sets the severity threshold to level #{args[:level]}" do


### PR DESCRIPTION
The Twiglet Logger now extends the standard Ruby Logger so that it conforms to a standard interface

# Notes
- The Twiglet logger will now accept blocks as well as strings and objects
- Callers now have the ability to set and read a log level threshold

See the Ruby Logger [documentation](https://rubydocs.org/d/ruby-2-6-3/classes/Logger.html) for more details
