### PR TITLE
Bugfix: New line not present after each log message

### DIFF
--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -63,6 +63,7 @@ module Twiglet
         .deep_merge(@default_properties.to_nested)
         .deep_merge(message.to_nested)
         .to_json
+        .concat("\n")
     end
   end
 end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -130,6 +130,18 @@ describe Twiglet::Logger do
       assert_equal 'Guinea pigs arrived', log[:message]
     end
 
+    it "should log multiple messages properly" do
+      @logger.debug({message: 'hi'})
+      @logger.info({message: 'there'})
+
+      expected_output =
+        '{"@timestamp":"2020-05-11T15:01:01.000Z","service":{"name":"petshop"},"log":{"level":"debug"},"message":"hi"}'\
+        "\n"\
+        '{"@timestamp":"2020-05-11T15:01:01.000Z","service":{"name":"petshop"},"log":{"level":"info"},"message":"there"}'
+
+      assert_equal expected_output, @buffer.string
+    end
+
     it 'should be able to convert dotted keys to nested objects' do
       @logger.debug({
                       "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -137,7 +137,8 @@ describe Twiglet::Logger do
       expected_output =
         '{"@timestamp":"2020-05-11T15:01:01.000Z","service":{"name":"petshop"},"log":{"level":"debug"},"message":"hi"}'\
         "\n"\
-        '{"@timestamp":"2020-05-11T15:01:01.000Z","service":{"name":"petshop"},"log":{"level":"info"},"message":"there"}'
+        '{"@timestamp":"2020-05-11T15:01:01.000Z","service":{"name":"petshop"},"log":{"level":"info"},"message":"there"}'\
+        "\n"\
 
       assert_equal expected_output, @buffer.string
     end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require_relative '../lib/twiglet/logger'
 
+# rubocop:disable Metrics/BlockLength
 describe Twiglet::Logger do
   before do
     @now = -> { Time.utc(2020, 5, 11, 15, 1, 1) }
@@ -311,3 +312,4 @@ describe Twiglet::Logger do
     JSON.parse(buffer.read, symbolize_names: true)
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
This should solve issues with Docker containers for example that only log once a new line is present.

Before:
```
{"@timestamp":"2020-06-25T08:49:44.039Z","service":{"name":"petshop"},"log":{"level":"info"},"event":{"action":"startup"},"message":"Ready to go, listening on port 8080","server":{"port":8080}}{"@timestamp":"2020-06-25T08:49:44.039Z","service":{"name":"petshop"},"log":{"level":"info"},"message":"Ready to go, listening on port 8080"}{"@timestamp":"2020-06-25T08:49:44.039Z","service":{"name":"petshop"},"log":{"level":"error"},"event":{"action":"HTTP request"},"trace":{"id":"126bb6fa-28a2-470f-b013-eefbf9182b2d"},"message":"DB connection failed.","error":{"message":"Connection timed-out"}}{"@timestamp":"2020-06-25T08:49:44.039Z","service":{"name":"petshop"},"log":{"level":"info"},"event":{"action":"HTTP request"},"trace":{"id":"126bb6fa-28a2-470f-b013-eefbf9182b2d"},"message":"Internal Server Error","http":{"request":{"method":"get"},"response":{"status_code":500}}}
```

After:
```
{"@timestamp":"2020-06-25T09:49:38.881Z","service":{"name":"petshop"},"log":{"level":"info"},"event":{"action":"startup"},"message":"Ready to go, listening on port 8080","server":{"port":8080}}
{"@timestamp":"2020-06-25T09:49:38.881Z","service":{"name":"petshop"},"log":{"level":"info"},"message":"Ready to go, listening on port 8080"}
{"@timestamp":"2020-06-25T09:49:38.881Z","service":{"name":"petshop"},"log":{"level":"error"},"event":{"action":"HTTP request"},"trace":{"id":"126bb6fa-28a2-470f-b013-eefbf9182b2d"},"message":"DB connection failed.","error":{"message":"Connection timed-out"}}
{"@timestamp":"2020-06-25T09:49:38.881Z","service":{"name":"petshop"},"log":{"level":"info"},"event":{"action":"HTTP request"},"trace":{"id":"126bb6fa-28a2-470f-b013-eefbf9182b2d"},"message":"Internal Server Error","http":{"request":{"method":"get"},"response":{"status_code":500}}}

```