### PR TITLE
Support initializing the logger with a log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ A hash can optionally be passed in as a keyword argument for `default_properties
 
 You may also provide an optional `output` keyword argument which should be an object with a `puts` method - like `$stdout`.
 
-Lastly, you can provide another optional keyword argument called `now`, which should be a function returning a `Time` string in ISO8601 format.
+In addition, you can provide another optional keyword argument called `now`, which should be a function returning a `Time` string in ISO8601 format.
+
+Lastly, you may provide the optional keyword argument `level` to initialize the logger with a severity threshold. Alternatively, the threshold can be updated at runtime by calling the `level` instance method.
 
 The defaults for both `output` and `now` should serve for most uses, though you may want to override them for testing as we have done [here](test/logger_test.rb).
 

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -14,17 +14,19 @@ module Twiglet
       service_name,
       default_properties: {},
       now: -> { Time.now.utc },
-      output: $stdout
+      output: $stdout,
+      level: Logger::DEBUG
     )
       @service_name = service_name
       @now = now
       @output = output
+      @level = level
 
       raise 'Service name is mandatory' \
         unless service_name.is_a?(String) && !service_name.strip.empty?
 
       formatter = Twiglet::Formatter.new(service_name, default_properties: default_properties, now: now)
-      super(output, formatter: formatter)
+      super(output, formatter: formatter, level: level)
     end
 
     def error(message = {}, error = nil, &block)
@@ -45,7 +47,8 @@ module Twiglet
       Logger.new(@service_name,
                  default_properties: default_properties,
                  now: @now,
-                 output: @output)
+                 output: @output,
+                 level: @level)
     end
 
     alias_method :warning, :warn

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.2.2'
+  VERSION = '2.2.3'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -307,7 +307,7 @@ describe Twiglet::Logger do
     end
 
     it 'initializes the logger with the provided level' do
-      assert_equal 2, Twiglet::Logger.new('petshop', level: :warn).level
+      assert_equal Logger::WARN, Twiglet::Logger.new('petshop', level: :warn).level
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -305,6 +305,10 @@ describe Twiglet::Logger do
         assert_equal args[:level], @logger.level
       end
     end
+
+    it 'initializes the logger with the provided level' do
+      assert_equal 2, Twiglet::Logger.new('petshop', level: :warn).level
+    end
   end
 
   private


### PR DESCRIPTION
# Changes
- allow caller to provide a log level threshold on initialization 
```ruby
logger = Twiglet::Logger.new('my service name', level: Logger::Warn)
```
- the log level threshold can be overridden at any point with the instance method 
```ruby
logger.level= Logger::Debug
```

@simplybusiness/application-tooling 